### PR TITLE
Move API key into env file for security

### DIFF
--- a/bus_synth.py
+++ b/bus_synth.py
@@ -13,11 +13,13 @@ from threading import Thread, Timer
 from typing import Dict, Any
 import matplotlib.pyplot as plt
 from oscillator_manager import OscillatorManager
+from dotenv import load_dotenv
 
+load_dotenv()
 
 class BusSynth:
     def __init__(self):
-        self.API_KEY = "I7Ozj1IWrV2b2owUdGqJi1CVJ4FFi5xm9fKdj5UB"
+        self.API_KEY = os.getenv('METLINK_API_KEY')
         self.BUS_URL = "https://api.opendata.metlink.org.nz/v1/gtfs-rt/vehiclepositions"
         self.STOP_URL = "https://api.opendata.metlink.org.nz/v1/gtfs/stops"
         self.UPDATES_URL = "https://api.opendata.metlink.org.nz/v1/gtfs-rt/tripupdates"


### PR DESCRIPTION
Hello! Not sure if it really matters, but might be best to switch to a new key and move it into an env rather than hardcode this into the repo, otherwise anyone will be able to use it. 